### PR TITLE
Add CSVW support

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "prosemirror-state": "^1.4.3",
     "prosemirror-view": "^1.37.2",
     "rdf-ext": "^2.5.2",
-    "rdfa-streaming-parser": "^3.0.1"
+    "rdfa-streaming-parser": "^3.0.1",
+    "uri-templates": "^0.2.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.9.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "micromark": "^4.0.0",
     "micromark-extension-gfm": "^3.0.0",
     "micromark-extension-gfm-tagfilter": "^2.0.0",
+    "papaparse": "^5.5.3",
     "prosemirror-commands": "^1.6.2",
     "prosemirror-example-setup": "^1.2.3",
     "prosemirror-history": "^1.4.1",

--- a/src/config.js
+++ b/src/config.js
@@ -446,6 +446,48 @@ export default {
     'http://www.w3.org/ns/ldp#Container'
   ],
 
+  STRIDEThreatTypes: {
+    Spoofing: [
+      'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Spoofing',
+      'https://w3id.org/dpv/risk#Spoofing',
+      'https://w3id.org/dpv/risk#IdentityFraud',
+      'https://w3id.org/dpv/risk#IdentityTheft',
+      'https://w3id.org/dpv/risk#PhishingScam'
+    ],
+    Tampering: [
+      'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Tampering',
+      'https://w3id.org/dpv/risk#UnauthorisedDataModification',
+      'https://w3id.org/dpv/risk#UnauthorisedCodeModification',
+      'https://w3id.org/dpv/risk#DataCorruption',
+      'https://w3id.org/dpv/risk#IntegrityBreach'
+    ],
+    Repudiation: [
+      'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Repudiation',
+      'https://w3id.org/dpv/risk#AuthorisationFailure',
+      'https://w3id.org/dpv/risk#LackOfSystemTransparency',
+      'https://w3id.org/dpv/risk#LoseTrust',
+      'https://w3id.org/dpv/risk#LoggingControl'
+    ],
+    InformationDisclosure: [
+      'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Information_Disclosure',
+      'https://w3id.org/dpv/risk#UnauthorisedInformationDisclosure',
+      'https://w3id.org/dpv/risk#UnauthorisedDataDisclosure',
+      'https://w3id.org/dpv/risk#UnwantedDisclosureData',
+      'https://w3id.org/dpv/risk#ConfidentialityBreach'
+    ],
+    DenialOfService: [
+      'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Denial_of_Service',
+      'https://w3id.org/dpv/risk#DenialServiceAttack',
+      'https://w3id.org/dpv/risk#AvailabilityBreach'
+    ],
+    ElevationOfPrivilege: [
+      'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Elevation_of_Privilege',
+      'https://w3id.org/dpv/risk#UnauthorisedDataAccess',
+      'https://w3id.org/dpv/risk#UnauthorisedSystemAccess',
+      'https://w3id.org/dpv/risk#UnauthorisedCodeAccess'
+    ]
+  },
+
   MediaTypes: {
     RDF: ['text/turtle', 'application/ld+json', 'application/activity+json', 'text/html', 'image/svg+xml', 'application/rdf+xml'],
 
@@ -493,6 +535,7 @@ export default {
     doap: rdf.namespace('http://usefulinc.com/ns/doap#'),
     doc: rdf.namespace('http://www.w3.org/2000/10/swap/pim/doc#'),
     doco: rdf.namespace('http://purl.org/spar/doco/'),
+    dpv: rdf.namespace('https://w3id.org/dpv#'),
     fabio: rdf.namespace('http://purl.org/spar/fabio/'),
     foaf: rdf.namespace('http://xmlns.com/foaf/0.1/'),
     ldp: rdf.namespace('http://www.w3.org/ns/ldp#'),
@@ -511,6 +554,7 @@ export default {
     rdfa: rdf.namespace(' http://www.w3.org/ns/rdfa#'),
     rdfs: rdf.namespace('http://www.w3.org/2000/01/rdf-schema#'),
     rel: rdf.namespace('https://www.w3.org/ns/iana/link-relations/relation#'),
+    risk: rdf.namespace('https://w3id.org/dpv/risk#'),
     rsa: rdf.namespace('http://www.w3.org/ns/auth/rsa#'),
     schema: rdf.namespace('http://schema.org/'),
     sio: rdf.namespace('http://semanticscience.org/resource/'),
@@ -519,6 +563,7 @@ export default {
     skosxl: rdf.namespace('http://www.w3.org/2008/05/skos-xl#'),
     solid: rdf.namespace('http://www.w3.org/ns/solid/terms#'),
     spec: rdf.namespace('http://www.w3.org/ns/spec#'),
+    tech: rdf.namespace('https://w3id.org/dpv/tech'),
     vcard: rdf.namespace('http://www.w3.org/2006/vcard/ns#'),
     void: rdf.namespace('http://rdfs.org/ns/void#'),
     wgs: rdf.namespace('http://www.w3.org/2003/01/geo/wgs84_pos#'),

--- a/src/config.js
+++ b/src/config.js
@@ -447,45 +447,69 @@ export default {
   ],
 
   STRIDEThreatTypes: {
-    Spoofing: [
-      'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Spoofing',
-      'https://w3id.org/dpv/risk#Spoofing',
-      'https://w3id.org/dpv/risk#IdentityFraud',
-      'https://w3id.org/dpv/risk#IdentityTheft',
-      'https://w3id.org/dpv/risk#PhishingScam'
-    ],
-    Tampering: [
-      'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Tampering',
-      'https://w3id.org/dpv/risk#UnauthorisedDataModification',
-      'https://w3id.org/dpv/risk#UnauthorisedCodeModification',
-      'https://w3id.org/dpv/risk#DataCorruption',
-      'https://w3id.org/dpv/risk#IntegrityBreach'
-    ],
-    Repudiation: [
-      'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Repudiation',
-      'https://w3id.org/dpv/risk#AuthorisationFailure',
-      'https://w3id.org/dpv/risk#LackOfSystemTransparency',
-      'https://w3id.org/dpv/risk#LoseTrust',
-      'https://w3id.org/dpv/risk#LoggingControl'
-    ],
-    InformationDisclosure: [
-      'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Information_Disclosure',
-      'https://w3id.org/dpv/risk#UnauthorisedInformationDisclosure',
-      'https://w3id.org/dpv/risk#UnauthorisedDataDisclosure',
-      'https://w3id.org/dpv/risk#UnwantedDisclosureData',
-      'https://w3id.org/dpv/risk#ConfidentialityBreach'
-    ],
-    DenialOfService: [
-      'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Denial_of_Service',
-      'https://w3id.org/dpv/risk#DenialServiceAttack',
-      'https://w3id.org/dpv/risk#AvailabilityBreach'
-    ],
-    ElevationOfPrivilege: [
-      'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Elevation_of_Privilege',
-      'https://w3id.org/dpv/risk#UnauthorisedDataAccess',
-      'https://w3id.org/dpv/risk#UnauthorisedSystemAccess',
-      'https://w3id.org/dpv/risk#UnauthorisedCodeAccess'
-    ]
+    S: {
+      uri: 'http://www.wikidata.org/entity/Q11081100',
+      name: 'Spoofing',
+      related: [
+        'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Spoofing',
+        'https://w3id.org/dpv/risk#Spoofing',
+        'https://w3id.org/dpv/risk#IdentityFraud',
+        'https://w3id.org/dpv/risk#IdentityTheft',
+        'https://w3id.org/dpv/risk#PhishingScam'
+      ]
+    },
+    T: {
+      uri: 'http://www.wikidata.org/entity/Q7681776',
+      name: 'Tampering',
+      related: [
+        'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Tampering',
+        'https://w3id.org/dpv/risk#UnauthorisedDataModification',
+        'https://w3id.org/dpv/risk#UnauthorisedCodeModification',
+        'https://w3id.org/dpv/risk#DataCorruption',
+        'https://w3id.org/dpv/risk#IntegrityBreach'
+      ]
+    },
+    R: {
+      uri: 'http://www.wikidata.org/entity/Q1327773',
+      name: 'Repudiation',
+      related: [
+        'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Repudiation',
+        'https://w3id.org/dpv/risk#AuthorisationFailure',
+        'https://w3id.org/dpv/risk#LackOfSystemTransparency',
+        'https://w3id.org/dpv/risk#LoseTrust',
+        'https://w3id.org/dpv/risk#LoggingControl'
+      ]
+    },
+    I: {
+      uri: 'http://www.wikidata.org/entity/Q2775060',
+      name: 'Information disclosure',
+      related: [
+        'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Information_Disclosure',
+        'https://w3id.org/dpv/risk#UnauthorisedInformationDisclosure',
+        'https://w3id.org/dpv/risk#UnauthorisedDataDisclosure',
+        'https://w3id.org/dpv/risk#UnwantedDisclosureData',
+        'https://w3id.org/dpv/risk#ConfidentialityBreach'
+      ]
+    },
+    D: {
+      uri: 'http://www.wikidata.org/entity/Q131406',
+      name: 'Denial of service',
+      related: [
+        'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Denial_of_Service',
+        'https://w3id.org/dpv/risk#DenialServiceAttack',
+        'https://w3id.org/dpv/risk#AvailabilityBreach'
+      ]
+    },
+    E: {
+      uri: 'http://www.wikidata.org/entity/Q1856893',
+      name: 'Elevation of privilege',
+      related: [
+        'http://www.grsu.by/net/SecurityPatternCatalogNaiveSchema#STRIDE_Elevation_of_Privilege',
+        'https://w3id.org/dpv/risk#UnauthorisedDataAccess',
+        'https://w3id.org/dpv/risk#UnauthorisedSystemAccess',
+        'https://w3id.org/dpv/risk#UnauthorisedCodeAccess'
+      ]
+    }
   },
 
   MediaTypes: {

--- a/src/config.js
+++ b/src/config.js
@@ -24,9 +24,9 @@ export default {
       DO.U.showAsTabs();
       DO.U.initDocumentActions();
       DO.U.showDocumentInfo();
+      DO.U.setDocumentMode();
       DO.U.showFragment();
       DO.U.initCopyToClipboard();
-      DO.U.setDocumentMode();
       DO.U.initEditor();
       DO.U.initMath();
       DO.U.initSlideshow();

--- a/src/csv.js
+++ b/src/csv.js
@@ -1,0 +1,216 @@
+import Papa from 'papaparse';
+import { domSanitize } from './util';
+
+export function csvStringToJson(str) { 
+  let json = Papa.parse(str);
+  return json;
+}
+
+export function jsonToHtmlTableString(obj, csvFilename, metadata) {
+  const dokieliStrideThreatModelCSVSchema = {
+    "@context": ["http://www.w3.org/ns/csvw", {"@language": "en"}],
+    "@type": "TableGroup",
+    "tables": [
+      {
+        "url": "dokieli-stride-threat-modeling.csv",
+        "dcterms:title": "Dokieli Threat Modeling - STRIDE",
+        "dcat:keyword": ['security risk', 'software security', 'software security assurance', 'threat modelling'],
+        "dcterms:publisher": "https://dokie.li/#i",
+        "dcterms:license": {"@id": "https://creativecommons.org/licenses/by/4.0/"},
+        "dcterms:modified": {"@value": "2025-08-19", "@type": "xsd:date"},
+        "tableSchema": {
+          "aboutUrl": "https://dokie.li/docs#assessment-2025-08-19-{_row}",
+          "columns": [
+            {
+              "name": "feature",
+              "titles": "Feature",
+              "datatype": "string",
+              "propertyUrl": "dcterms:subject",
+              "valueUrl": "{feature}",
+              "required": true
+            },
+            {
+              "name": "strideThreatType",
+              "titles": "STRIDE threat type",
+              "datatype": "string",
+              "aboutUrl": "#{risk}",
+              "propertyUrl": "dpv:hasImpact",
+              "valueUrl": "#{strideThreatType",
+              "null": ["N/A", ""]
+            },
+            {
+              "name": "risk",
+              "titles": "Risk",
+              "datatype": "string",
+              "propertyUrl": "risk:hasRisk",
+              "valueUrl": "#{risk}",
+              "null": ["N/A", ""]
+            },
+            {
+              "name": "riskLevel",
+              "titles": "Risk level",
+              "datatype": "string",
+              "aboutUrl": "#{risk}",
+              "propertyUrl": "risk:hasRiskLevel",
+              "valueUrl": "https://w3id.org/dpv/risk#{riskLevel}",
+              "null": ["N/A", ""]
+            },
+            {
+              "name": "mitigation",
+              "titles": "Mitigation",
+              "datatype": "string",
+              "aboutUrl": "#{risk}",
+              "propertyUrl": "risk:isMitigatedByMeasure",
+              "valueUrl": "#{mitigation}",
+              "null": ["N/A", ""]
+            },
+            {
+              "name": "description",
+              "titles": "Description",
+              "datatype": "string",
+              "propertyUrl": "dcterms:description",
+              "null": ["N/A", ""]
+            },
+            {
+              "name": "issue",
+              "titles": "Issue",
+              "datatype": "string",
+              "propertyUrl": "rdfs:seeAlso",
+              "valueUrl": "{feature}",
+              "null": ["N/A", ""]
+            }
+          ]
+        }
+      },
+      {
+        "url": "risks.csv",
+        "tableSchema": {
+          "columns": [
+            {
+              "name": "risk",
+              "titles": "Risk",
+              "datatype": "string",
+              "propertyUrl": "rdf:type",
+              "valueUrl": "dpv:Risk"
+            },
+            {
+              "name": "description",
+              "titles": "Description",
+              "datatype": "string",
+              "aboutUrl": "{risk}",
+              "propertyUrl": "dcterms:description",
+            }
+          ]
+        }
+      },
+      {
+        "url": "mitigations.csv",
+        "tableSchema": {
+          "columns": [
+            {
+              "name": "mitigation",
+              "titles": "Mitigation",
+              "datatype": "string",
+              "propertyUrl": "rdf:type",
+              "valueUrl": "dpv:RiskMitigationMeasure"
+            },
+            {
+              "name": "description",
+              "titles": "Description",
+              "datatype": "string",
+              "aboutUrl": "{mitigation}",
+              "propertyUrl": "dcterms:description",
+            }
+          ]
+        }
+      }
+    ]
+  }
+
+  let language, url;
+
+  const isPlainObject = (object) => {
+    return Object.prototype.toString.call(value) === '[object Object]';
+  }
+
+  //http://www.w3.org/TR/tabular-data-model/
+  if (metadata && metadata['@context'] && (metadata['@context'] == 'http://www.w3.org/ns/csvw' || metadata['@context'].includes('http://www.w3.org/ns/csvw') )) {
+    if (Array.isArray(metadata['@context'])) {
+      metadata['@context'].forEach(i => {
+        if (isPlainObject(i)) {
+          if (i['@language']) {
+            language = i['@language'];
+          }
+        }
+      })
+    }
+  }
+
+  let caption = metadata['dc:title'] || metadata['@id'] || csvFilename;
+  let keywords = metadata['dcat:keyword'];
+  let publisher = metadata['dc:publisher'];
+  let creator = metadata['dc:creator'];
+  let license = metadata['dc:license'];
+  let modified = metadata['dc:modified'];
+  let columns = metadata['columns'];
+
+  const { data } = obj;
+  if (!data || data.length === 0) return "<table></table>";
+  
+  const headers = data[0];
+  const rows = data.slice(1);
+
+//TODO: strideThreatType S or Spoofing
+
+  let html = "<table>";
+  html += `<caption>${caption}</caption>`;
+
+  html += "<thead><tr>";
+  headers.forEach(header => {
+    header = escapeHtml(domSanitize(header));
+    html += `<th>${header}</th>`;
+  });
+  html += "</tr></thead>";
+
+  html += "<tbody>";
+  rows.forEach(row => {
+    html += "<tr>";
+    row.forEach((cell, i) => {
+      const columnName = headers[i];
+      const currentColumn = columns.find(col => col.name === columnName);
+      cell = escapeHtml(domSanitize(cell));
+
+      htmlAttribute = ''
+
+      //TODO: aboutUrl
+      //TODO: valueUrl
+
+      if (currentColumn.datatype == 'string') {
+        htmlAttribute
+      }
+
+      html += `<td${currentColumn.propertyUrl}>${cell}</td>`;
+    });
+
+    html += "</tr>";
+  });
+  html += "</tbody>";
+
+  // html += "<tfoot>";
+
+  // html += "</tfoot>";
+
+  html += "</table>";
+
+  return html;
+}
+
+function escapeHtml(str) {
+  if (str === null || str === undefined) return "";
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}

--- a/src/csv.js
+++ b/src/csv.js
@@ -1,17 +1,17 @@
+import Config from './config.js'
 import Papa from 'papaparse';
 import { domSanitize } from './util.js';
 import { escapeCharacters } from './doc.js';
+import uriTemplates from 'uri-templates';
 
-export function csvStringToJson(str) { 
-  let json = Papa.parse(str);
-  return json;
+export function csvStringToJson(str) {
+  return Papa.parse(str.trim());
 }
 
 //https://www.w3.org/TR/tabular-data-model/
 //https://www.w3.org/TR/csv2rdf/
 //https://www.w3.org/TR/tabular-metadata/
 export function jsonToHtmlTableString(csvTables, metadata) {
-
   metadata = metadata || {
     "@context": [
       "http://www.w3.org/ns/csvw",
@@ -118,6 +118,7 @@ export function jsonToHtmlTableString(csvTables, metadata) {
       },
       {
         "url": "risks.csv",
+        "dcterms:title": [{"@value": "Risks", "@language": "en"}],
         "tableSchema": {
           "primaryKey": "risk",
           "aboutUrl": "#{risk}",
@@ -140,6 +141,7 @@ export function jsonToHtmlTableString(csvTables, metadata) {
       },
       {
         "url": "mitigations.csv",
+        "dcterms:title": [{"@value": "Mitigations", "@language": "en"}],
         "tableSchema": {
           "primaryKey": "mitigation",
           "aboutUrl": "#{mitigation}",
@@ -184,39 +186,63 @@ export function jsonToHtmlTableString(csvTables, metadata) {
   if (!metadata.tables && !metadata.tables.length) { return }
 
   let tables = metadata.tables;
-  console.log(tables)
 
-  let caption = metadata['dcterms:title'] || metadata['@id'];
-  let keywords = metadata['dcat:keyword'];
-  let publisher = metadata['dcterms:publisher'];
-  let creator = metadata['dcterms:creator'];
-  let license = metadata['dcterms:license'];
-  let modified = metadata['dcterms:modified'];
+  const uriTemplateProperties = ['aboutUrl', 'propertyUrl', 'valueUrl'];
+
+  const orderMap = metadata.tables.reduce((acc, table, index) => {
+    acc[table.url] = index;
+    return acc;
+  }, {});
+
+  csvTables = csvTables.sort((a, b) => {
+    const ai = orderMap[a.url] ?? Number.MAX_SAFE_INTEGER;
+    const bi = orderMap[b.url] ?? Number.MAX_SAFE_INTEGER;
+    return ai - bi;
+  });
 
   let html = '';
-  csvTables.forEach((obj) => {
-    const tableMetadata = tables.find((table) => table.url === obj.url)
-    const metadataColumns = tableMetadata.tableSchema.columns;
-    const tableAboutUrl = tableMetadata.tableSchema.aboutUrl;
 
-    let attributeTypeOf;
-    let attributeProperty;
-    let attributeHrefRel;
-    let attributeAboutId;
-    
-    if (tableAboutUrl) {
-      attributeAboutId = ` about="${tableAboutUrl}" id="${tableAboutUrl.slice(1)}"`;
-    }
+  let tablesList = {};
+
+  csvTables.forEach((obj) => {
+    const tableMetadata = tables.find((table) => table.url === obj.url);
+
+    let caption = tableMetadata['dcterms:title'] || tableMetadata['url'] || tableMetadata['@id'];
+    caption = Array.isArray(caption) ? caption[0] : caption;
+
+    let keywordsHTML = JSONLDArrayToDL(tableMetadata['dcat:keyword'], 'Keywords', 'dcat:keyword');
+    let publisher = tableMetadata['dcterms:publisher'];
+    publisher = Array.isArray(publisher) ? publisher[0] : publisher;
+    let license = tableMetadata['dcterms:license'];
+    let modified = tableMetadata['dcterms:modified'];
+
+    const metadataColumns = tableMetadata.tableSchema.columns;
+    const metadataColumnsCount = metadataColumns.length;
+    const tableSchemaAboutUrl = tableMetadata.tableSchema.aboutUrl;
+    let foreignKeys = tableMetadata.tableSchema.foreignKeys
+    foreignKeys = foreignKeys ? foreignKeys.map((foreignKeyObj) => foreignKeyObj.columnReference) : [];
+    let attributeAboutId = '';
+
+    let uriTemplate;
+    let tableSchemaAboutUrlValue;
 
     const { data } = obj;
     if (!data || data.length === 0 ) return "<table></table>";
     const headers = data[0];
     const rows = data.slice(1);
-  
-  //TODO: strideThreatType S or Spoofing
-  
-    html += `<table>`;
-    html += `<caption>${caption}</caption>`;
+
+    let captionLang = '';
+    if (isPlainObject(caption)) {
+      const captionValue = caption["@value"];
+
+      captionLang = ` lang="${caption["@language"]}" xml:lang="${caption["@language"]}"`;
+      caption = captionValue;
+    }
+
+    tablesList[tableMetadata['url']] = caption;
+
+    html += `<table id="${tableMetadata['url']}">`;
+    html += `<caption${captionLang}>${caption}</caption>`;
   
     html += `<thead><tr>`;
     headers.forEach(header => {
@@ -224,100 +250,189 @@ export function jsonToHtmlTableString(csvTables, metadata) {
       html += `<th>${header}</th>`;
     });
     html += `</tr></thead>`;
-  
+
     html += `<tbody>`;
-    rows.forEach(row => {
+    rows.forEach((row, rowIndex) => {
+      const fillValues = headers.reduce((acc, header) => {
+        acc[header] = getValueByHeader(row, headers, header);
+        return acc;
+      }, {});
+
+      fillValues['_row'] = rowIndex;
+
+      if (tableSchemaAboutUrl) {
+        uriTemplate = uriTemplates(domSanitize(tableSchemaAboutUrl));
+
+        tableSchemaAboutUrlValue = uriTemplate.fill(fillValues);
+
+        attributeAboutId = ` about="${tableSchemaAboutUrlValue}" id="${tableSchemaAboutUrlValue.slice(1)}"`;
+      }
+
       html += `<tr${attributeAboutId}>`;
-      row.forEach((cell, i) => {
-        const columnName = headers[i];
-  
-        const currentColumnMetadata = metadataColumns.find(col => col.name === columnName);
+
+      row.forEach((cell, cellIndex) => {
+        const columnName = headers[cellIndex];
         if (!columnName) return;
-
         cell = escapeCharacters(domSanitize(cell));
-        const metadataValueUrl = metadataColumns.valueUrl;
-        const templateRegex = /#\{(.*?)\}/g;
-        const variables = getUriTemplateVariables(metadataValueUrl);
-        console.log(variables)
-        let valueUrl = metadataValueUrl;
-        variables?.forEach(variable => {
-          if (!valueUrl) return;
-          valueUrl = valueUrl.replace(templateRegex, getValueByHeader(row, headers, variable))
+
+        const currentColumnMetadataOriginal = metadataColumns.find(col => col.name === columnName);
+        const currentColumnMetadata = { ...currentColumnMetadataOriginal };
+        
+        const nullValues = currentColumnMetadata.null || [];
+
+        const cellFillValues = headers.reduce((acc, header) => {
+          let val = getValueByHeader(row, headers, header);
+          acc[header] = val;
+          return acc;
+        }, {});
+
+        fillValues['_row'] = rowIndex;
+
+        let isInForeignKeys = !!foreignKeys.includes(currentColumnMetadata.name)
+
+        let skipProperty = false;
+
+        Object.keys(currentColumnMetadata).forEach(key => {
+          if (uriTemplateProperties.includes(key)) {
+            const uriTemplate = uriTemplates(currentColumnMetadata[key]);
+            let isNull = false;
+            uriTemplate.varNames.forEach((v) => {
+              if (foreignKeys.includes(v) && v !== currentColumnMetadata.name) {
+                isInForeignKeys = true;
+                isNull = nullValues.includes(cellFillValues[v]);
+                if (isNull) {
+                  skipProperty = true;
+                }
+              }
+            })
+
+            currentColumnMetadata[key] = isNull ? null : domSanitize(uriTemplate.fill(cellFillValues));
+          }
         })
-console.log(valueUrl)
-        const columnAboutUrl = currentColumnMetadata.aboutUrl;
-        aboutUrl = columnAboutUrl || tableAboutUrl;
 
-        if (aboutUrl) {
-          attributeAboutId = ` about="${aboutUrl}" id="${aboutUrl.slice(1)}"`;
+        const attributes = []
+
+        if (currentColumnMetadata.aboutUrl) {
+          attributes.push(`about="${currentColumnMetadata.aboutUrl}"`)
+          if (!isInForeignKeys) {
+            attributes.push(`id="${currentColumnMetadata.aboutUrl.slice(1)}"`);
+          }
         }
 
-        if (currentColumnMetadata.propertyUrl == 'rdf:type') {
-          attributeTypeOf = ` typeof="${currentColumnMetadata.valueUrl}"`;
+        let childWithAttribute;
+
+        if (currentColumnMetadata.propertyUrl) {
+          if (currentColumnMetadata.propertyUrl == 'rdf:type') {
+            let aboutUrl = currentColumnMetadata.aboutUrl || tableSchemaAboutUrlValue;
+
+            attributes.push(`about="${aboutUrl}"`);
+
+            if (!tableSchemaAboutUrlValue && !isInForeignKeys) {
+              attributes.push(`id="${aboutUrl.slice(1)}"`);
+            }
+            
+            if (currentColumnMetadata.valueUrl) {
+              attributes.push(`typeof="${currentColumnMetadata.valueUrl}"`);
+            }
+            else {
+              attributes.push(`typeof="${cell}"`);
+            }
+          }
+
+          if (currentColumnMetadata.propertyUrl == 'dcterms:description') {
+            attributes.push(`property="${currentColumnMetadata.propertyUrl}"`);
+          }
+
+          if (currentColumnMetadata.propertyUrl !== 'rdf:type' && currentColumnMetadata.propertyUrl !== 'dcterms:description' && currentColumnMetadata.valueUrl) {
+            if (currentColumnMetadata.name == 'strideThreatType') {
+              let valueUrlSliced = currentColumnMetadata.valueUrl.slice(1);
+              let strideThreatType = Config.STRIDEThreatTypes[valueUrlSliced];
+
+              if (strideThreatType) {
+                cell = strideThreatType.name;
+                currentColumnMetadata.valueUrl = strideThreatType.uri;
+              }
+            }
+
+            let hrefValue;
+            let relAttribute = '';
+
+            if ((currentColumnMetadata.propertyUrl == 'dcterms:subject' || currentColumnMetadata.propertyUrl == 'rdfs:seeAlso') && URL.canParse(cell)) {
+              hrefValue = cell;
+            }
+
+            if (!skipProperty) {
+              relAttribute = ` rel="${currentColumnMetadata.propertyUrl}"`;
+            }
+
+            childWithAttribute = `<a href="${hrefValue ?? currentColumnMetadata.valueUrl}"${relAttribute}>${cell}</a>`;
+          }
+          else {
+            childWithAttribute = cell;
+          }
+        }
+        else {
+          childWithAttribute = `<span property="${columnName}">${cell}</span>`;
         }
 
-        if (currentColumnMetadata.propertyUrl == 'dcterms:description') {
-          attributeProperty = ` property="${currentColumnMetadata.propertyUrl}"`;
+        if (nullValues.includes(cell)) {
+          html += `<td>${cell}</td>`;
         }
-
-        if (currentColumnMetadata.propertyUrl && currentColumnMetadata.valueUrl) {
-          attributeHrefRel = `<a href="${currentColumnMetadata.valueUrl}" rel="${currentColumnMetadata.propertyUrl}">${currentColumnMetadata.valueUrl}</a>`;
+        else {
+          html += `<td ${attributes.join(' ')}>${childWithAttribute}</td>`;
         }
-
-  let tr = `
-    <tr${attributeAboutId}${attributeTypeOf}>
-      <td>${risk}</td>
-      <td${attributeProperty}>${description}</td>
-    </tr>
-  `;
-
-        html += `<td property="${currentColumnMetadata.propertyUrl}">${cell}</td>`;
-
-    'https://w3id.org/dpv/risk#Spoofing',
-    'https://w3id.org/dpv/risk#IdentityFraud',
-    'https://w3id.org/dpv/risk#IdentityTheft',
-    'https://w3id.org/dpv/risk#PhishingScam'
-
-`
-<th>feature</th><th>strideThreatType</th><th>risk</th><th>riskLevel</th><th>mitigation</th><th>description</th><th>issue</th>
-`
-`
-  <tbody>
-    <tr about="${aboutUrl}">
-      <td><a href="https://dokie.li/docs#feature-approving" rel="dcterms:subject">https://dokie.li/docs#feature-approving</td>
-      <td rel="stride:threatType"><span resource="stride:Spoofing">S</a></span></td>
-      <td><a href="#${risk}" rel="dpv:hasImpact">foo</a></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-  </tbody>
-`;
-
-
-
-
-
-
-
-      });
-  
+      })
       html += `</tr>`;
     });
+
     html += `</tbody>`;
-  
-    // html += "<tfoot>";
-  
-    // html += "</tfoot>";
-  
+    let publisherHTML = '', publisherHref, publisherName;
+
+    let licenseHTML = '', licenseHref, licenseName;
+
+    if (isPlainObject(publisher)) {
+      publisherHref = publisher["@id"] || publisher["schema:url"];
+      publisherHref = publisherHref["@id"] ? publisherHref["@id"] : publisherHref;
+      publisherName = (publisher["schema:name"]) ? publisher["schema:name"] : publisherHref;
+    }
+    else {
+      publisherHref = publisher;
+    }
+    if (publisher) {
+      publisherHTML = `<dl><dt>Publisher</dt><dd><a href="${publisherHref}" rel="dcterms:publisher">${publisherName}</a></dd></dl>`;
+    }
+
+    if (isPlainObject(license)) {
+      licenseHref = license["@id"] || publisher["schema:url"];
+
+      licenseName = (licenseHref && Config.License[licenseHref]) ? Config.License[licenseHref].name : licenseHref;
+    }
+
+    if (license) {
+      licenseHTML = `<dl><dt>License</dt><dd><a href="${licenseHref}" rel="dcterms:license">${licenseName}</a></dd></dl>`;
+    }
+
+    if (publisherHTML !== '' || licenseHTML !== '' || keywordsHTML !== '') {
+      html += `<tfoot><tr><td colspan="${metadataColumnsCount}">${publisherHTML}${licenseHTML}${keywordsHTML}</td></tr></tfoot>`;
+    }
+
     html += `</table>`;
   })
 
-console.log(html)
-  return html;
+
+  //TODO: buildListOfStuff('list-of-tables') could do this but it inserts its HTML, and jsonToHtmlTableString is called later.
+  let navList = [];
+  let navHtml = '';
+
+  Object.keys(tablesList).forEach(key => {
+    navList.push(`<li><a href="#${key}">${tablesList[key]}</a></li>`);
+  })
+
+  if (navList.length) {
+    navHtml = `<nav id="list-of-tables"><h2>Tables</h2><div><ol class="toc">${navList.join('')}</ol></div></nav>`;
+  }
+
+  return navHtml + html;
 }
 
 function getValueByHeader(row, headers, headerName) {
@@ -325,26 +440,13 @@ function getValueByHeader(row, headers, headerName) {
   return index !== -1 ? row[index] : undefined;
 }
 
-//TODO: use https://www.npmjs.com/package/uri-templates instead :
 
-function getUriTemplateVariables(uri) {
-/*
-{
-  fill: [Function (anonymous)],
-  fromUri: [Function (anonymous)],
-  varNames: [ 'colour', 'shape' ],
-  template: '/date/{colour}/{shape}/'
-}
-*/
+function JSONLDArrayToDL(arr, title, property) {
+  if (!Array.isArray(arr) || arr.length === 0) return '';
 
-  // return uriTemplates(uri)
+  const items = arr.map(
+    k => `<dd lang="${k['@language']}" property="${property}" xml:lang="${k['@language']}">${k['@value']}</dd>`
+  ).join('');
 
-
-
-
-  if (!uri) return;
-  //uri = https://example.org/{foo}/{bar}/baz
-  const matches = [...uri.matchAll(/#\{([^}]+)\}/g)].map(m => m[1]);
-  //Output: ["foo", "bar"]
-  return matches;
+  return `<dl><dt>${title}</dt>${items}</dl>`;
 }

--- a/src/doc.js
+++ b/src/doc.js
@@ -1220,7 +1220,7 @@ function createDateHTML(options) {
 
   var title = ('title' in options) ? options.title : 'Created';
 
-  var id = ('id' in options && options.id.length > 0) ? ' id="' + options.id + '"' : ' id="document-' + title.toLowerCase().replace(/\W/g, '-') + '"';
+  var id = ('id' in options && options.id.length > 0) ? ' id="' + options.id + '"' : '';
 
   var c = ('class' in options && options.class.length > 0) ? ' class="' + options.class + '"' : '';
 

--- a/src/dokieli.js
+++ b/src/dokieli.js
@@ -7233,33 +7233,28 @@ console.log('XXX: Cannot access effectiveACLResource', e);
         const csvFiles = [];
 
         files.map((file) => {
-          if (file.name.endsWith("-metadata.json")) {
+          if (file.name.endsWith("metadata.json")) {
             metadataFiles.push(file);
           }
           if (file.type === 'text/csv') {
+            console.log(file)
             csvFiles.push(file)
           }
         })
 
         // handle multiple csv
-        const jsonObjects = csvFiles.map(csvFile => csvStringToJson(csvFile.content))
-
-        jsonObjects.forEach((obj) => {
-          let metadata = {};
-
-          if (metadataFiles.length) {
-            metadataFiles.forEach((mf) => {
-              let tmp = JSON.parse(mf.content);
-
-              if (metadata.url == file.name) {
-                metadata = tmp;
-              }
-            })
-          }
-
-          const htmlString = jsonToHtmlTableString(obj, file.name, metadata)
-          console.log(htmlString)
+        const jsonObjects = csvFiles.map(csvFile => {
+          let tmp = csvStringToJson(csvFile.content);
+          tmp['url'] = csvFile.name;
+          return tmp;
         })
+
+        let metadata;
+        if (metadataFiles[0] && metadataFiles[0].content) {
+          metadata = JSON.parse(metadataFiles[0].content);
+        }
+        const htmlString = jsonToHtmlTableString(jsonObjects, metadata)
+        console.log(htmlString)
 
       }
 
@@ -7274,7 +7269,8 @@ console.log('XXX: Cannot access effectiveACLResource', e);
           console.log("single csv case", iri, files);
           // TODO: the below will be a function later
           let jsonObject = csvStringToJson(files[0].content); // we only have one for now
-          const htmlString = jsonToHtmlTableString(jsonObject, files[0].name, {});
+          jsonObject['url'] = files[0].name;
+          const htmlString = jsonToHtmlTableString([jsonObject], {});
           console.log(htmlString)
           break;
 

--- a/src/dokieli.js
+++ b/src/dokieli.js
@@ -1629,7 +1629,7 @@ DO = {
 
           DO.U.openResource(open);
         }
-
+        // FIXME: we shouldn't have to call this here too, but there is a situation where the other if block gets triggered before we resolved this one. review and fix.
         let paramGraphView = getUrlParams('graph-view');
 
         if (paramGraphView.length && paramGraphView[0] == 'true') {

--- a/src/uri.js
+++ b/src/uri.js
@@ -204,6 +204,21 @@ function getPrefixedNameFromIRI(iri) {
   }
 
   return iri;
+} 
+
+function getIRIFromPrefix(qname) {
+  const qnameParts = qname.slice(':');
+
+  if (qnameParts.length == 2) {
+    let prefix = qnameParts[0];
+    let localName = qnameParts[1];
+
+    if (prefix.length && localName.length && ns[prefix].value) {
+       return ns[prefix].value + localName;
+    }
+  }
+
+  return qname;
 }
 
 
@@ -293,6 +308,7 @@ export {
   getLastPathSegment,
   generateDataURI,
   getPrefixedNameFromIRI,
+  getIRIFromPrefix,
   getMediaTypeURIs,
   isHttpOrHttpsProtocol,
   isHttpsProtocol,


### PR DESCRIPTION
This has been a fantastic side quest as part of dokieli security audit and threat modeling.

Gained +100 exp :gem: . Infinite fun :mushroom: .

* Implements most common functionalities of CSVW: [Metadata Vocabulary for Tabular Data](https://www.w3.org/TR/tabular-metadata/), [Generating RDF from Tabular Data on the Web](https://www.w3.org/TR/csv2rdf/), [Model for Tabular Data and Metadata on the Web](https://www.w3.org/TR/tabular-data-model/) .
* Supports opening multiple CSV resources (local and remote) with CSVW metadata handling.
* Converts CSVW data to HTML+RDFa tables.
* Enable multiple `open` params in URL.
* Add `graph-view` param in URL for any resources.
* Also support combining `open` and `graph-view`.
* Add STRIDE Threat Types and relations to [DPV](https://w3id.org/dpv).
* Opening CSVW supports DPV and [RISK](https://w3id.org/dpv/risk).
* Use URI Templates.

Here is a screencast showing the local CSVs and metadata of the dokieli threat model opened and viewed:

[dokieli-csvw-threat-modeling.webm](https://github.com/user-attachments/assets/976acd5d-3dcb-4d99-ae05-d741d71ce1a1)

Source: https://dokie.li/media/video/dokieli-csvw-threat-modeling.webm