### PR TITLE
Fix: persistence of authenticated session

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@shower/core": "^3.3.0",
-    "@uvdsl/solid-oidc-client-browser": "^0.2.1",
+    "@uvdsl/solid-oidc-client-browser": "^0.2.2",
     "buffer": "^6.0.3",
     "d3-force": "^3.0.0",
     "d3-selection": "^3.0.0",

--- a/src/auth.js
+++ b/src/auth.js
@@ -8,6 +8,7 @@ import { removeLocalStorageAsSignOut, updateLocalStorageProfile } from './storag
 import { updateButtons, getButtonHTML } from './ui/buttons.js';
 import { SessionCore } from '@uvdsl/solid-oidc-client-browser/core';
 import { isCurrentScriptSameOrigin, isLocalhost } from './uri.js';
+import { SessionIDB } from '@uvdsl/solid-oidc-client-browser';
 
 const ns = Config.ns;
 
@@ -17,10 +18,11 @@ const clientid = (Config.OIDC['client_id']) ? Config.OIDC['client_id'] : null;
 
 const currentScriptSameOrigin = isCurrentScriptSameOrigin();
 
-Config['Session'] = (clientid && !Config['WebExtensionEnabled'] && currentScriptSameOrigin) ? new SessionCore({ client_id: clientid }) : new SessionCore();
+Config['Session'] = (clientid && !Config['WebExtensionEnabled'] && currentScriptSameOrigin) ? new SessionCore({ client_id: clientid }, { database: new SessionIDB() }) : new SessionCore(undefined, { database: new SessionIDB() });
 
 export async function restoreSession() {
   await Config['Session']?.handleRedirectFromLogin();
+  await Config['Session']?.restore().catch(e => console.log(e.message));
 }
 
 async function showUserSigninSignout (node) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1432,12 +1432,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uvdsl/solid-oidc-client-browser@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "@uvdsl/solid-oidc-client-browser@npm:0.2.1"
+"@uvdsl/solid-oidc-client-browser@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "@uvdsl/solid-oidc-client-browser@npm:0.2.2"
   dependencies:
     jose: "npm:^5.9.6"
-  checksum: 10c0/017abab0a18cb685fa513374f6094648d69507de6bac01956066c6590bb05309967db53837537c652414d38696b96d41970010fc49d8aa13e9a712021cfc81cd
+  checksum: 10c0/ce67477999ae9044c09d5ef17fe9b4e6b49b9ee35262e2a3508e2c3f82ccc013b85e127ecbad3fcb662fe126b8424e1c63622d14b7342a4bdda1014de21e1aec
   languageName: node
   linkType: hard
 
@@ -2479,7 +2479,7 @@ __metadata:
     "@axe-core/playwright": "npm:^4.9.1"
     "@playwright/test": "npm:^1.44.1"
     "@shower/core": "npm:^3.3.0"
-    "@uvdsl/solid-oidc-client-browser": "npm:^0.2.1"
+    "@uvdsl/solid-oidc-client-browser": "npm:^0.2.2"
     "@vitest/coverage-istanbul": "npm:^3.1.4"
     "@vitest/coverage-v8": "npm:^3.1.4"
     babel-eslint: "npm:^10.1.0"


### PR DESCRIPTION
**Problem:** When navigating to a different page, the authenticated session was lost.

**Solution:** After the small patch on `@uvdsl/solid-oidc-client-browser` to expose the `SessionIDB` for you to use directly, we could:
- updated @uvdsl/solid-oidc-client-browser to v0.2.2
- use SessionIDB / IndexedDB for persistence when creating the `Session`
- add `session.restore()` call when loading a page to refresh tokens and thus restore a session

See also the rough [API documentation / example](https://github.com/uvdsl/solid-oidc-client-browser/wiki/API-Reference#using-the-core-for-extensions-and-custom-setups).