### PR TITLE
Check user's preferred languages and update UI

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -20,7 +20,7 @@ import Config from './config.js'
 import { removeChildren, fragmentFromString } from './util.js'
 import { getAgentHTML, showActionMessage, showGeneralMessages, getResourceSupplementalInfo, handleDeleteNote, addMessageToLog } from './doc.js'
 import { Icon } from './ui/icons.js'
-import { getResourceGraph, getAgentName, getGraphImage, getAgentURL, getAgentPreferredProxy, getAgentPreferredPolicy, setPreferredPolicyInfo, getAgentDelegates, getAgentKnows, getAgentFollowing, getAgentStorage, getAgentOutbox, getAgentInbox, getAgentPreferencesFile, getAgentPublicTypeIndex, getAgentPrivateTypeIndex, getAgentTypeIndex, getAgentSupplementalInfo, getAgentSeeAlso, getAgentPreferencesInfo, getAgentLiked, getAgentOccupations, getAgentPublications, getAgentMade, getAgentOIDCIssuer } from './graph.js'
+import { getResourceGraph, getAgentName, getGraphImage, getAgentURL, getAgentPreferredProxy, getAgentPreferredPolicy, setPreferredPolicyInfo, getAgentDelegates, getAgentKnows, getAgentFollowing, getAgentStorage, getAgentOutbox, getAgentInbox, getAgentPreferencesFile, getAgentPublicTypeIndex, getAgentPrivateTypeIndex, getAgentTypeIndex, getAgentSupplementalInfo, getAgentSeeAlso, getAgentPreferencesInfo, getAgentLiked, getAgentOccupations, getAgentPublications, getAgentMade, getAgentOIDCIssuer, getAgentPreferredLanguages, setPreferredLanguagesInfo } from './graph.js'
 import { removeLocalStorageAsSignOut, updateLocalStorageProfile } from './storage.js'
 import { updateButtons, getButtonHTML } from './ui/buttons.js';
 import { SessionCore } from '@uvdsl/solid-oidc-client-browser/core';
@@ -332,6 +332,7 @@ function getSubjectInfo (subjectIRI, options = {}) {
         OIDCIssuer: getAgentOIDCIssuer(g),
         ProxyURL: getAgentPreferredProxy(g),
         PreferredPolicy: getAgentPreferredPolicy(g),
+        PreferredLanguages: getAgentPreferredLanguages(g),
         Delegates: getAgentDelegates(g),
         Contacts: {},
         Knows: getAgentKnows(g),
@@ -351,6 +352,13 @@ function getSubjectInfo (subjectIRI, options = {}) {
         Publications: getAgentPublications(g),
         Made: getAgentMade(g)
       }
+    })
+    .then(agent => {
+      if (!agent.Graph) return agent;
+
+      setPreferredLanguagesInfo(agent.Graph);
+
+      return agent;
     })
     .then(agent => {
       //XXX: Revisit what the retun should be, whether to be undefined, {}, or someting else. Is it useful to retain an agent object that doesn't have a Graph? (Probably better not.)
@@ -389,10 +397,12 @@ function afterSetUserInfo () {
       })
       .then(g => {
         setPreferredPolicyInfo(g);
+        setPreferredLanguagesInfo(g);
       })
       .catch(error => {
         var g = Config.User.Graph.node(rdf.namedNode(Config.User.IRI));
         setPreferredPolicyInfo(g);
+        setPreferredLanguagesInfo(g);
       }))
 
     promises.push(getAgentSupplementalInfo(Config.User.IRI))

--- a/src/dokieli.js
+++ b/src/dokieli.js
@@ -2784,72 +2784,76 @@ DO = {
         e.preventDefault();
         e.stopPropagation();
 
-        i18n.changeLanguage(e.target.value, (err) => {
-          if (err) return console.error('Error loading language', err);
+        DO.U.updateUILanguage(e.target.value);
+      });
+    },
 
-          // re-run initButtons to update the buttons that are stored
-          initButtons();
+    updateUILanguage(lang) {
+      i18n.changeLanguage(lang, (err) => {
+        if (err) return console.error('Error loading language', err);
 
-          Config.User.UI['Language'] = e.target.value;
-          Config.User.UI['LanguageDir'] = i18n.dir(); 
+        // re-run initButtons to update the buttons that are stored
+        initButtons();
 
-          document.querySelectorAll('.do[lang]').forEach(el => {
-            el.setAttribute('lang', e.target.value);
-            el.setAttribute('xml:lang', e.target.value);
-            el.setAttribute('dir', Config.User.UI['LanguageDir']);
-          })
+        Config.User.UI['Language'] = lang;
+        Config.User.UI['LanguageDir'] = i18n.dir();
 
-          document.querySelectorAll('.do select[name$="-language"]').forEach(el => {
-            el.value = e.target.value;
-          })
+        document.querySelectorAll('.do[lang]').forEach(el => {
+          el.setAttribute('lang', lang);
+          el.setAttribute('xml:lang', lang);
+          el.setAttribute('dir', Config.User.UI['LanguageDir']);
+        })
 
-          document.querySelectorAll('[data-i18n]:not(.ProseMirror [data-i18n]').forEach(el => {
-            const baseKey = el.dataset.i18n;
+        document.querySelectorAll('.do select[name$="-language"], .do select#ui-language-select').forEach(el => {
+          el.value = lang;
+        })
 
-            //TODO: Revisit updating text
+        document.querySelectorAll('[data-i18n]:not(.ProseMirror [data-i18n]').forEach(el => {
+          const baseKey = el.dataset.i18n;
 
-            // Update textContent
-            const textKey = `${baseKey}.textContent`;
-            const textValue = i18n.t(textKey);
-            if (textValue !== textKey) {
-              const span = el.querySelector(':scope > span');
-              if (span) {
-                span.textContent = textValue;
-              } else {
-                [...el.childNodes].forEach(node => {
-                  if (node.nodeType === Node.TEXT_NODE && node.nodeValue.trim()) {
-                    node.nodeValue = textValue;
-                  }
-                });
-              }
+          //TODO: Revisit updating text
+
+          // Update textContent
+          const textKey = `${baseKey}.textContent`;
+          const textValue = i18n.t(textKey);
+          if (textValue !== textKey) {
+            const span = el.querySelector(':scope > span');
+            if (span) {
+              span.textContent = textValue;
+            } else {
+              [...el.childNodes].forEach(node => {
+                if (node.nodeType === Node.TEXT_NODE && node.nodeValue.trim()) {
+                  node.nodeValue = textValue;
+                }
+              });
             }
+          }
 
-            // Update innerHTML
-            const htmlKey = `${baseKey}.innerHTML`;
+          // Update innerHTML
+          const htmlKey = `${baseKey}.innerHTML`;
 
-            // TODO: move to a standalone function - this takes the variable names from data-i18n- suffix and passes them as a vars object to the i18n fn
-            const vars = {};
-            Object.entries(el.dataset).forEach(([name, value]) => {
-              if (name !== 'i18n') {
-                vars[name.replace(/^i18n/, '').toLowerCase()] = value;
-              }
-            });
-
-            const translated = i18n.t(htmlKey, vars);
-
-            if (translated !== htmlKey) {
-              el.setHTMLUnsafe(domSanitize(translated));
+          // TODO: move to a standalone function - this takes the variable names from data-i18n- suffix and passes them as a vars object to the i18n fn
+          const vars = {};
+          Object.entries(el.dataset).forEach(([name, value]) => {
+            if (name !== 'i18n') {
+              vars[name.replace(/^i18n/, '').toLowerCase()] = value;
             }
+          });
 
-            // Update attributes
-            [...el.attributes].forEach(attr => {
-              if (attr.name === 'data-i18n') return;
-              const attrKey = `${baseKey}.${attr.name}`;
-              const value = i18n.t(attrKey);
-              if (value !== attrKey) {
-                el.setAttribute(attr.name, value);
-              }
-            });
+          const translated = i18n.t(htmlKey, vars);
+
+          if (translated !== htmlKey) {
+            el.setHTMLUnsafe(domSanitize(translated));
+          }
+
+          // Update attributes
+          [...el.attributes].forEach(attr => {
+            if (attr.name === 'data-i18n') return;
+            const attrKey = `${baseKey}.${attr.name}`;
+            const value = i18n.t(attrKey);
+            if (value !== attrKey) {
+              el.setAttribute(attr.name, value);
+            }
           });
         });
       });

--- a/src/graph.js
+++ b/src/graph.js
@@ -827,6 +827,18 @@ function setPreferredPolicyInfo(g) {
   Config.User['PreferredPolicyRule'] = getAgentPreferredPolicyRule(s);
 }
 
+function setPreferredLanguagesInfo(g) {
+  const preferredLanguages = getAgentPreferredLanguages(g);
+
+  const lang = preferredLanguages.find(lang => {
+    return Config.Translations.includes(lang);
+  });
+
+  if (lang) {
+    DO.U.updateUILanguage(lang);
+  }
+}
+
 //TODO: Review grapoi
 function getAgentSupplementalInfo(iri) {
   if (iri == Config.User.IRI) {
@@ -1141,6 +1153,17 @@ function getAgentPreferredProxy (s) {
 
 function getAgentPreferredPolicy (s) {
   return s.out(ns.solid.preferredPolicy).values[0] || undefined
+}
+
+function getAgentPreferredLanguages (s) {
+  var vcardLanguages = s.out(ns.vcard.language).values;
+  var solidPreferredLanguages = s.out(ns.solid.preferredLanguage).values;
+
+  return (
+    vcardLanguages.length > 0 ? vcardLanguages :
+    solidPreferredLanguages.length > 0 ? solidPreferredLanguages :
+    undefined
+  );
 }
 
 //TODO: undefined?
@@ -1725,6 +1748,7 @@ export {
   getAgentPreferencesInfo,
   getAgentPreferredPolicyRule,
   setPreferredPolicyInfo,
+  setPreferredLanguagesInfo,
   getAgentSeeAlso,
   getAgentSupplementalInfo,
   getUserContacts,
@@ -1732,6 +1756,7 @@ export {
   processSameAs,
   getAgentPreferredProxy,
   getAgentPreferredPolicy,
+  getAgentPreferredLanguages,
   getAgentOIDCIssuer,
   getAgentName,
   getAgentURL,


### PR DESCRIPTION
This PR checks the user's preferred languages and then updates the UI if there is a translation available. Fallback is based on browser's `accept-language` header or defaults to English (which is the source language for the application) if other options are not available.

Completes the work on language detection in various ways (browser setting, user's preferred language, user selection).